### PR TITLE
feat(ECOM-23): logout-feature

### DIFF
--- a/lib/config/routing/app_routes.dart
+++ b/lib/config/routing/app_routes.dart
@@ -6,4 +6,5 @@ abstract class AppRoutes {
   static const String resetPassword = "/resetPassword";
   static const String mainLayout = "/mainLayout";
   static const String changePassword = "/changePassword";
+  static const String logout = "/logout";
 }

--- a/lib/config/routing/route_generator.dart
+++ b/lib/config/routing/route_generator.dart
@@ -3,9 +3,11 @@ import 'package:flowers_ecommerce_app/features/auth/forget_password/presentation
 import 'package:flowers_ecommerce_app/features/auth/forget_password/presentation/pages/forget_password_screen.dart';
 import 'package:flowers_ecommerce_app/features/auth/forget_password/presentation/pages/reset_password.dart';
 import 'package:flowers_ecommerce_app/features/auth/login/presentation/pages/login_screen.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/presentation/pages/logout_screen.dart';
 import 'package:flowers_ecommerce_app/features/auth/register/presentation/pages/register_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+
 import '../../features/auth/change_password/presentation/presentation/pages/reset_password_screen.dart';
 import '../../features/main_layout/main_layout.dart';
 import 'app_routes.dart';
@@ -44,6 +46,9 @@ class RouteGenerator {
 
       case AppRoutes.changePassword:
         return MaterialPageRoute(builder: (_) => const ChangePasswordScreen());
+
+      case AppRoutes.logout:
+        return MaterialPageRoute(builder: (context) => const LogoutScreen(),);
 
       default:
         return unDefinedRoute();

--- a/lib/config/routing/route_generator.dart
+++ b/lib/config/routing/route_generator.dart
@@ -48,7 +48,7 @@ class RouteGenerator {
         return MaterialPageRoute(builder: (_) => const ChangePasswordScreen());
 
       case AppRoutes.logout:
-        return MaterialPageRoute(builder: (context) => const LogoutScreen(),);
+        return MaterialPageRoute(builder: (context) => const LogoutScreen());
 
       default:
         return unDefinedRoute();

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -54,5 +54,6 @@
   "password_must_not_be_empty_and_must_contain_6_characters_with_upper_case_letter_and_one_number_at_least": "Password must not be empty and must contain\n 6 characters with upper case letter and one\n number at least",
   "password_is_required": "Password is required",
   "password_must_be_at_least_6_characters": "Password must be at least 6 characters",
-  "passwords_do_not_match": "Passwords do not match"
+  "passwords_do_not_match": "Passwords do not match",
+  "logout": "Logout"
 }

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -55,5 +55,8 @@
   "password_is_required": "Password is required",
   "password_must_be_at_least_6_characters": "Password must be at least 6 characters",
   "passwords_do_not_match": "Passwords do not match",
-  "logout": "Logout"
+  "logout": "Logout",
+  "confirm_logout": "Confirm Logout!!",
+  "cancel": "Cancel",
+  "logout_successfully": "Logout Successfully"
 }

--- a/lib/core/network/api_constants.dart
+++ b/lib/core/network/api_constants.dart
@@ -7,4 +7,5 @@ abstract class ApiConstants {
   static const String verifyResetCode = "auth/verifyResetCode";
   static const String resetPassword = "auth/resetPassword";
   static const String changePassword = "auth/change-password";
+  static const String logout = "auth/logout";
 }

--- a/lib/core/network/api_services.dart
+++ b/lib/core/network/api_services.dart
@@ -12,6 +12,7 @@ import 'package:retrofit/retrofit.dart';
 
 import '../../features/auth/change_password/data/models/request/change_password_request_dto.dart';
 import '../../features/auth/change_password/data/models/response/change_password_response_dto.dart';
+import '../../features/auth/logout/data/models/logout_response_dto.dart';
 
 part 'api_services.g.dart';
 
@@ -39,4 +40,9 @@ abstract class ApiServices {
     @Body() ChangePasswordRequestDto requestDto,
     @Header(ApiConstants.authorization) String token,
   );
+
+  @GET(ApiConstants.logout)
+  Future<LogoutResponseDto> logout(
+      @Header(ApiConstants.authorization) String token);
+
 }

--- a/lib/core/network/api_services.dart
+++ b/lib/core/network/api_services.dart
@@ -43,6 +43,6 @@ abstract class ApiServices {
 
   @GET(ApiConstants.logout)
   Future<LogoutResponseDto> logout(
-      @Header(ApiConstants.authorization) String token);
-
+    @Header(ApiConstants.authorization) String token,
+  );
 }

--- a/lib/features/auth/login/presentation/pages/login_screen.dart
+++ b/lib/features/auth/login/presentation/pages/login_screen.dart
@@ -65,10 +65,7 @@ class _LoginScreenState extends State<LoginScreen> {
                   AppLocalizations.of(context)!.login_successfully,
                 );
 
-                Navigator.pushReplacementNamed(
-                  context,
-                  AppRoutes.resetPassword,
-                );
+                Navigator.pushReplacementNamed(context, AppRoutes.logout);
               }
             },
             builder: (BuildContext context, LoginState state) {

--- a/lib/features/auth/logout/data/data_sources/logout_ds.dart
+++ b/lib/features/auth/logout/data/data_sources/logout_ds.dart
@@ -1,0 +1,5 @@
+import 'package:flowers_ecommerce_app/features/auth/logout/data/models/logout_response_dto.dart';
+
+abstract interface class LogoutDataSource {
+  Future<LogoutResponseDto> logout();
+}

--- a/lib/features/auth/logout/data/data_sources/logout_ds_impl.dart
+++ b/lib/features/auth/logout/data/data_sources/logout_ds_impl.dart
@@ -1,0 +1,21 @@
+import 'package:flowers_ecommerce_app/features/auth/logout/data/data_sources/logout_ds.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/data/models/logout_response_dto.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../../core/network/api_services.dart';
+import '../../../../../core/services/token_service.dart';
+import '../../../../../core/utils/app_constants.dart';
+
+@Injectable(as: LogoutDataSource)
+class LogoutDataSourceImpl implements LogoutDataSource {
+  final ApiServices _apiServices;
+  final TokenService _tokenService;
+
+  LogoutDataSourceImpl(this._apiServices, this._tokenService);
+
+  @override
+  Future<LogoutResponseDto> logout() async {
+    final token = await _tokenService.getToken() as String;
+    return await _apiServices.logout("${AppConstants.bearer} $token");
+  }
+}

--- a/lib/features/auth/logout/data/models/logout_response_dto.dart
+++ b/lib/features/auth/logout/data/models/logout_response_dto.dart
@@ -1,0 +1,23 @@
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/entities/logout_response_entity.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'logout_response_dto.g.dart';
+
+@JsonSerializable()
+class LogoutResponseDto {
+  @JsonKey(name: "message")
+  final String? message;
+
+  LogoutResponseDto({this.message});
+
+  factory LogoutResponseDto.fromJson(Map<String, dynamic> json) {
+    return _$LogoutResponseDtoFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() {
+    return _$LogoutResponseDtoToJson(this);
+  }
+
+  LogoutResponseEntity toLogoutResponseEntity() =>
+      LogoutResponseEntity(message: message);
+}

--- a/lib/features/auth/logout/data/repositories/logout_repo_impl.dart
+++ b/lib/features/auth/logout/data/repositories/logout_repo_impl.dart
@@ -1,0 +1,34 @@
+import 'package:dio/dio.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/entities/logout_response_entity.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/repositories/logout_repo.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../../core/errors/api_results.dart';
+import '../../../../../core/errors/failures.dart';
+import '../data_sources/logout_ds.dart';
+
+@Injectable(as: LogoutRepo)
+class LogoutRepoImpl implements LogoutRepo {
+  final LogoutDataSource _dataSource;
+
+  LogoutRepoImpl(this._dataSource);
+
+  @override
+  Future<ApiResult<LogoutResponseEntity>> logout() async {
+    try {
+      final dtoResponse = await _dataSource.logout();
+
+      return ApiSuccessResult<LogoutResponseEntity>(
+        data: dtoResponse.toLogoutResponseEntity(),
+      );
+    } on DioException catch (e) {
+      return ApiErrorResult<LogoutResponseEntity>(
+        failure: ServerFailure.fromDioError(dioException: e),
+      );
+    } catch (e) {
+      return ApiErrorResult<LogoutResponseEntity>(
+        failure: Failure(errorMessage: e.toString()),
+      );
+    }
+  }
+}

--- a/lib/features/auth/logout/domain/entities/logout_response_entity.dart
+++ b/lib/features/auth/logout/domain/entities/logout_response_entity.dart
@@ -1,0 +1,5 @@
+class LogoutResponseEntity {
+  LogoutResponseEntity({this.message});
+
+  String? message;
+}

--- a/lib/features/auth/logout/domain/repositories/logout_repo.dart
+++ b/lib/features/auth/logout/domain/repositories/logout_repo.dart
@@ -1,0 +1,8 @@
+import 'package:flowers_ecommerce_app/core/errors/api_results.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/entities/logout_response_entity.dart';
+
+abstract interface class LogoutRepo {
+  LogoutRepo();
+
+  Future<ApiResult<LogoutResponseEntity>> logout();
+}

--- a/lib/features/auth/logout/domain/use_cases/logout_use_case.dart
+++ b/lib/features/auth/logout/domain/use_cases/logout_use_case.dart
@@ -1,0 +1,14 @@
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/repositories/logout_repo.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../../core/errors/api_results.dart';
+import '../entities/logout_response_entity.dart';
+
+@injectable
+class LogoutUseCase {
+  final LogoutRepo _repo;
+
+  LogoutUseCase(this._repo);
+
+  Future<ApiResult<LogoutResponseEntity>> invoke() => _repo.logout();
+}

--- a/lib/features/auth/logout/presentation/manager/logout_cubit.dart
+++ b/lib/features/auth/logout/presentation/manager/logout_cubit.dart
@@ -1,0 +1,41 @@
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/entities/logout_response_entity.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/use_cases/logout_use_case.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/presentation/manager/logout_event.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/presentation/manager/logout_state.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../../core/errors/api_results.dart';
+
+@injectable
+class LogoutCubit extends Cubit<LogoutState> {
+  LogoutCubit(this.useCase) : super(const LogoutState());
+  LogoutUseCase useCase;
+
+  doIntent(LogoutEvent event) {
+    switch (event) {
+      case SubmitLogoutEvent():
+        _logout();
+        break;
+    }
+  }
+
+  Future<void> _logout() async {
+    emit(state.copyWith(isLoading: true, isSuccess: false, errorMsg: null));
+
+    var result = await useCase.invoke();
+
+    switch (result) {
+      case ApiSuccessResult<LogoutResponseEntity>():
+        emit(state.copyWith(isLoading: false, isSuccess: true));
+        break;
+      case ApiErrorResult<LogoutResponseEntity>():
+        emit(
+          state.copyWith(
+            isLoading: false,
+            errorMsg: result.failure.errorMessage,
+          ),
+        );
+    }
+  }
+}

--- a/lib/features/auth/logout/presentation/manager/logout_event.dart
+++ b/lib/features/auth/logout/presentation/manager/logout_event.dart
@@ -1,0 +1,3 @@
+sealed class LogoutEvent {}
+
+class SubmitLogoutEvent extends LogoutEvent {}

--- a/lib/features/auth/logout/presentation/manager/logout_state.dart
+++ b/lib/features/auth/logout/presentation/manager/logout_state.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+
+class LogoutState extends Equatable {
+  final bool isLoading;
+  final bool isSuccess;
+  final String? errorMsg;
+
+  const LogoutState({
+    this.isLoading = false,
+    this.isSuccess = false,
+    this.errorMsg,
+  });
+
+  LogoutState copyWith({String? errorMsg, bool? isLoading, bool? isSuccess}) {
+    return LogoutState(
+      isSuccess: isSuccess ?? this.isSuccess,
+      isLoading: isLoading ?? this.isLoading,
+      errorMsg: errorMsg ?? this.errorMsg,
+    );
+  }
+
+  @override
+  List<Object?> get props => [isLoading, isSuccess, errorMsg];
+}

--- a/lib/features/auth/logout/presentation/pages/logout_screen.dart
+++ b/lib/features/auth/logout/presentation/pages/logout_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../../core/di/di.dart';
-import '../manager/logout_event.dart';
+import '../widgets/logout_alert_dialogue.dart';
 
 class LogoutScreen extends StatelessWidget {
   const LogoutScreen({super.key});
@@ -14,18 +14,14 @@ class LogoutScreen extends StatelessWidget {
     return BlocProvider(
       create: (context) => getIt<LogoutCubit>(),
       child: Scaffold(
-        body: InkWell(
-          onTap: () => getIt<LogoutCubit>().doIntent(SubmitLogoutEvent()),
-          child: Expanded(
-            child: Row(
-              children: [
-                const Icon(Icons.logout),
-                Text(AppLocalizations.of(context)!.logout),
-                const Align(
-                  alignment: Alignment.centerRight,
-                  child: Icon(Icons.logout),
-                ),
-              ],
+        body: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Center(
+            child: ListTile(
+              leading: const Icon(Icons.logout),
+              title: Text(AppLocalizations.of(context)!.logout),
+              trailing: const Icon(Icons.logout),
+              onTap: () => _logout(context),
             ),
           ),
         ),
@@ -34,63 +30,14 @@ class LogoutScreen extends StatelessWidget {
   }
 }
 
-void logout(context) {
-  showDialog(context: context, builder: (context) => const LogoutDialog());
-}
-
-class LogoutDialog extends StatelessWidget {
-  const LogoutDialog({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      title: const Center(
-        child: Text("LOGOUT", style: TextStyle(fontWeight: FontWeight.bold)),
-      ),
-      content: const Text("Confirm logout!!", textAlign: TextAlign.center),
-      actionsAlignment: MainAxisAlignment.center,
-      actions: [
-        Row(
-          children: [
-            OutlinedButton(
-              style: OutlinedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30),
-                ),
-                side: const BorderSide(color: Colors.black26),
-              ),
-              onPressed: () {
-                Navigator.of(context).pop(); // إغلاق الديالوج
-              },
-              child: const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                child: Text("Cancel"),
-              ),
-            ),
-
-            // Logout button
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.pink,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30),
-                ),
-              ),
-              onPressed: () {
-                // هنا تحط كود تسجيل الخروج
-                Navigator.of(context).pop();
-              },
-              child: const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                child: Text("Logout"),
-              ),
-            ),
-          ],
-        ),
-
-        // Cancel button
-      ],
-    );
-  }
+void _logout(context) {
+  showDialog(
+    context: context,
+    builder: (_) {
+      return BlocProvider.value(
+        value: getIt<LogoutCubit>(),
+        child: const LogoutAlertDialogue(),
+      );
+    },
+  );
 }

--- a/lib/features/auth/logout/presentation/pages/logout_screen.dart
+++ b/lib/features/auth/logout/presentation/pages/logout_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flowers_ecommerce_app/core/l10n/translations/app_localizations.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/presentation/manager/logout_cubit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/di/di.dart';
+import '../manager/logout_event.dart';
+
+class LogoutScreen extends StatelessWidget {
+  const LogoutScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => getIt<LogoutCubit>(),
+      child: Scaffold(
+        body: InkWell(
+          onTap: () => getIt<LogoutCubit>().doIntent(SubmitLogoutEvent()),
+          child: Expanded(
+            child: Row(
+              children: [
+                const Icon(Icons.logout),
+                Text(AppLocalizations.of(context)!.logout),
+                const Align(
+                  alignment: Alignment.centerRight,
+                  child: Icon(Icons.logout),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void logout(context) {
+  showDialog(context: context, builder: (context) => const LogoutDialog());
+}
+
+class LogoutDialog extends StatelessWidget {
+  const LogoutDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: const Center(
+        child: Text("LOGOUT", style: TextStyle(fontWeight: FontWeight.bold)),
+      ),
+      content: const Text("Confirm logout!!", textAlign: TextAlign.center),
+      actionsAlignment: MainAxisAlignment.center,
+      actions: [
+        Row(
+          children: [
+            OutlinedButton(
+              style: OutlinedButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(30),
+                ),
+                side: const BorderSide(color: Colors.black26),
+              ),
+              onPressed: () {
+                Navigator.of(context).pop(); // إغلاق الديالوج
+              },
+              child: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                child: Text("Cancel"),
+              ),
+            ),
+
+            // Logout button
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.pink,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(30),
+                ),
+              ),
+              onPressed: () {
+                // هنا تحط كود تسجيل الخروج
+                Navigator.of(context).pop();
+              },
+              child: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                child: Text("Logout"),
+              ),
+            ),
+          ],
+        ),
+
+        // Cancel button
+      ],
+    );
+  }
+}

--- a/lib/features/auth/logout/presentation/widgets/logout_alert_dialogue.dart
+++ b/lib/features/auth/logout/presentation/widgets/logout_alert_dialogue.dart
@@ -1,0 +1,100 @@
+import 'package:flowers_ecommerce_app/config/routing/app_routes.dart';
+import 'package:flowers_ecommerce_app/config/routing/routing_extensions.dart';
+import 'package:flowers_ecommerce_app/core/helpers/flutter_toast.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/helpers/spacing.dart';
+import '../../../../../core/l10n/translations/app_localizations.dart';
+import '../../../../../core/utils/font_weight.dart';
+import '../manager/logout_cubit.dart';
+import '../manager/logout_event.dart';
+import '../manager/logout_state.dart';
+
+class LogoutAlertDialogue extends StatelessWidget {
+  const LogoutAlertDialogue({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context)!;
+    final ThemeData theme = Theme.of(context);
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: Text(
+        localizations.logout,
+        textAlign: TextAlign.center,
+        style: theme.textTheme.labelMedium!.copyWith(
+          fontWeight: AppFontWeight.semiBold,
+        ),
+      ),
+      content: Text(
+        localizations.confirm_logout,
+        textAlign: TextAlign.center,
+        style: theme.textTheme.displayMedium!.copyWith(
+          color: theme.colorScheme.secondary,
+        ),
+      ),
+      actionsAlignment: MainAxisAlignment.center,
+      actions: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                style: OutlinedButton.styleFrom(
+                  shape: const StadiumBorder(),
+                  side: BorderSide(color: theme.colorScheme.onSurface),
+                ),
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+                child: Text(
+                  localizations.cancel,
+                  style: theme.textTheme.displaySmall!.copyWith(
+                    color: theme.colorScheme.onSurface,
+                  ),
+                ),
+              ),
+            ),
+            horizontalSpace(12),
+            Expanded(
+              child: BlocListener<LogoutCubit, LogoutState>(
+                listener: (context, state) {
+                  if (state.errorMsg != null) {
+                    context.pop();
+                    ToastMessage.toastMsg(
+                      state.errorMsg!,
+                      backgroundColor: theme.colorScheme.error,
+                    );
+                  }
+                  if (state.isSuccess) {
+                    context.pop();
+                    context.pushNamedAndRemoveUntil(
+                      AppRoutes.login,
+                      predicate: (route) => true,
+                    );
+                    ToastMessage.toastMsg(localizations.logout_successfully);
+                  }
+                },
+                child: OutlinedButton(
+                  style: OutlinedButton.styleFrom(
+                    backgroundColor: Colors.pink,
+                    shape: const StadiumBorder(),
+                  ),
+                  onPressed: () =>
+                      context.read<LogoutCubit>().doIntent(SubmitLogoutEvent()),
+                  child: Text(
+                    localizations.logout,
+                    style: theme.textTheme.displayMedium!.copyWith(
+                      color: theme.colorScheme.onPrimary,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flowers_ecommerce_app/config/routing/app_routes.dart';
 import 'package:flowers_ecommerce_app/core/di/di.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+
 import 'config/routing/route_generator.dart';
 import 'config/theme/app_theme.dart';
 import 'core/l10n/translations/app_localizations.dart';
@@ -28,7 +29,7 @@ class FlowersEcommerce extends StatelessWidget {
         supportedLocales: AppLocalizations.supportedLocales,
         debugShowCheckedModeBanner: false,
         onGenerateRoute: RouteGenerator.getRoute,
-        initialRoute: AppRoutes.login,
+        initialRoute: AppRoutes.logout,
         theme: AppTheme.lightTheme,
       ),
     );

--- a/test/features/auth/logout/data/data_sources/logout_ds_impl_test.dart
+++ b/test/features/auth/logout/data/data_sources/logout_ds_impl_test.dart
@@ -1,0 +1,42 @@
+import 'package:flowers_ecommerce_app/core/network/api_services.dart';
+import 'package:flowers_ecommerce_app/core/services/token_service.dart';
+import 'package:flowers_ecommerce_app/core/utils/app_constants.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/data/data_sources/logout_ds_impl.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/data/models/logout_response_dto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../change_password/data/data_sources/change_password_ds_impl_test.mocks.dart';
+
+@GenerateMocks([ApiServices, TokenService])
+void main() {
+  final ApiServices apiServices = MockApiServices();
+  final TokenService tokenService = MockTokenService();
+  final LogoutDataSourceImpl dataSource = LogoutDataSourceImpl(
+    apiServices,
+    tokenService,
+  );
+
+  test(
+    'verify when call logout it should call logout from ApiServices',
+    () async {
+      final expectedResponse = LogoutResponseDto(message: "Good");
+
+      const String token = "asfaf";
+
+      when(tokenService.getToken()).thenAnswer((_) async => token);
+      when(
+        apiServices.logout("${AppConstants.bearer} $token"),
+      ).thenAnswer((_) async => expectedResponse);
+
+      var result = await dataSource.logout();
+
+      verify(tokenService.getToken()).called(1);
+      verify(apiServices.logout("${AppConstants.bearer} $token")).called(1);
+
+      expect(result, isA<LogoutResponseDto>());
+      expect(result.message, equals(expectedResponse.message));
+    },
+  );
+}

--- a/test/features/auth/logout/data/models/logout_response_dto_test.dart
+++ b/test/features/auth/logout/data/models/logout_response_dto_test.dart
@@ -1,0 +1,27 @@
+import 'package:flowers_ecommerce_app/features/auth/logout/data/models/logout_response_dto.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/entities/logout_response_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'when call toLogoutResponseEntity with null values should return LogoutResponseEntity with null values',
+    () {
+      final LogoutResponseDto dto = LogoutResponseDto(message: null);
+
+      final LogoutResponseEntity entity = dto.toLogoutResponseEntity();
+
+      expect(entity.message, null);
+    },
+  );
+
+  test(
+    'when call toLogoutResponseEntity with non-Null values should return LogoutResponseEntity with correct values',
+    () {
+      final LogoutResponseDto dto = LogoutResponseDto(message: "Hello");
+
+      final LogoutResponseEntity entity = dto.toLogoutResponseEntity();
+
+      expect(entity.message, dto.message);
+    },
+  );
+}

--- a/test/features/auth/logout/data/repositories/logout_repo_impl_test.dart
+++ b/test/features/auth/logout/data/repositories/logout_repo_impl_test.dart
@@ -1,7 +1,66 @@
+import 'package:dio/dio.dart';
+import 'package:flowers_ecommerce_app/core/errors/api_results.dart';
+import 'package:flowers_ecommerce_app/core/errors/failures.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/data/data_sources/logout_ds.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/data/models/logout_response_dto.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/data/repositories/logout_repo_impl.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/entities/logout_response_entity.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'logout_repo_impl_test.mocks.dart';
+
+@GenerateMocks([LogoutDataSource])
 void main() {
-  test('TODO: Implement tests for logout_repo_impl.dart', () {
-    // TODO: Implement test
+  final LogoutDataSource dataSource = MockLogoutDataSource();
+  final LogoutRepoImpl repoImpl = LogoutRepoImpl(dataSource);
+  final LogoutResponseDto expectedResponse = LogoutResponseDto(message: "Good");
+
+  test('should return ApiSuccessResult when successfully', () async {
+    when(dataSource.logout()).thenAnswer((_) async => expectedResponse);
+
+    final result = await repoImpl.logout();
+
+    verify(dataSource.logout()).called(1);
+
+    expect(result, isA<ApiSuccessResult<LogoutResponseEntity>>());
+    result as ApiSuccessResult<LogoutResponseEntity>;
+    expect(result.data, isA<LogoutResponseEntity>());
   });
+
+  test('should return ApiErrorResult when DioException is thrown', () async {
+    final throwenException = DioException(
+      requestOptions: RequestOptions(path: "/logout"),
+      type: DioExceptionType.connectionTimeout,
+    );
+
+    when(dataSource.logout()).thenThrow(throwenException);
+
+    final result = await repoImpl.logout();
+
+    verify(dataSource.logout()).called(1);
+
+    expect(result, isA<ApiErrorResult<LogoutResponseEntity>>());
+    result as ApiErrorResult<LogoutResponseEntity>;
+    expect(result.failure, isA<ServerFailure>());
+  });
+
+  test(
+    'should return ApiErrorResult when unexpected error is thrown',
+    () async {
+      final throwenException = Exception("unexpected error");
+
+      when(dataSource.logout()).thenThrow(throwenException);
+
+      final result = await repoImpl.logout();
+
+      verify(dataSource.logout()).called(1);
+
+      expect(result, isA<ApiErrorResult<LogoutResponseEntity>>());
+      result as ApiErrorResult<LogoutResponseEntity>;
+      expect(result.failure, isA<Failure>());
+      expect(result.failure.errorMessage, throwenException.toString());
+    },
+  );
 }

--- a/test/features/auth/logout/data/repositories/logout_repo_impl_test.dart
+++ b/test/features/auth/logout/data/repositories/logout_repo_impl_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('TODO: Implement tests for logout_repo_impl.dart', () {
+    // TODO: Implement test
+  });
+}

--- a/test/features/auth/logout/domain/use_cases/logout_use_case_test.dart
+++ b/test/features/auth/logout/domain/use_cases/logout_use_case_test.dart
@@ -1,0 +1,40 @@
+import 'package:flowers_ecommerce_app/core/errors/api_results.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/entities/logout_response_entity.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/repositories/logout_repo.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/use_cases/logout_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'logout_use_case_test.mocks.dart';
+
+@GenerateMocks([LogoutRepo])
+void main() {
+  final LogoutRepo repo = MockLogoutRepo();
+  final LogoutUseCase useCase = LogoutUseCase(repo);
+
+  final LogoutResponseEntity expectedResponse = LogoutResponseEntity(
+    message: "Good",
+  );
+
+  provideDummy<ApiResult<LogoutResponseEntity>>(
+    ApiSuccessResult<LogoutResponseEntity>(data: expectedResponse),
+  );
+
+  test(
+    'When call invoke fun should return ApiSuccessResult when repo returns success',
+    () async {
+      when(repo.logout()).thenAnswer(
+        (_) async =>
+            ApiSuccessResult<LogoutResponseEntity>(data: expectedResponse),
+      );
+
+      final result = await useCase.invoke();
+
+      verify(repo.logout()).called(1);
+      expect(result, isA<ApiSuccessResult<LogoutResponseEntity>>());
+      result as ApiSuccessResult<LogoutResponseEntity>;
+      expect(result.data, equals(expectedResponse));
+    },
+  );
+}

--- a/test/features/auth/logout/presentation/manager/logout_cubit_test.dart
+++ b/test/features/auth/logout/presentation/manager/logout_cubit_test.dart
@@ -1,0 +1,58 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flowers_ecommerce_app/core/errors/api_results.dart';
+import 'package:flowers_ecommerce_app/core/errors/failures.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/entities/logout_response_entity.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/domain/use_cases/logout_use_case.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/presentation/manager/logout_cubit.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/presentation/manager/logout_event.dart';
+import 'package:flowers_ecommerce_app/features/auth/logout/presentation/manager/logout_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'logout_cubit_test.mocks.dart';
+
+@GenerateMocks([LogoutUseCase])
+void main() {
+  group("Change Password View Model test ", () {
+    final LogoutUseCase useCase = MockLogoutUseCase();
+
+    final LogoutResponseEntity response = LogoutResponseEntity(message: "Good");
+
+    final ApiResult<LogoutResponseEntity> successResponse =
+        ApiSuccessResult<LogoutResponseEntity>(data: response);
+    final ApiResult<LogoutResponseEntity> errorResponse = ApiErrorResult(
+      failure: Failure(errorMessage: "Something went wrong"),
+    );
+
+    provideDummy<ApiResult<LogoutResponseEntity>>(successResponse);
+
+    blocTest<LogoutCubit, LogoutState>(
+      "call doIntent with SubmitLogoutEvent then call _submitChangePassword and return success",
+      build: () {
+        when(useCase.invoke()).thenAnswer((_) async => successResponse);
+        return LogoutCubit(useCase);
+      },
+      act: (viewModel) async => await viewModel.doIntent(SubmitLogoutEvent()),
+      expect: () => [
+        const LogoutState(isLoading: true),
+        const LogoutState(isLoading: false, isSuccess: true),
+      ],
+      verify: (_) => verify(useCase.invoke()).called(1),
+    );
+
+    blocTest<LogoutCubit, LogoutState>(
+      "call doIntent with SubmitLogoutEvent then call _submitChangePassword and return error",
+      build: () {
+        when(useCase.invoke()).thenAnswer((_) async => errorResponse);
+        return LogoutCubit(useCase);
+      },
+      act: (viewModel) async => await viewModel.doIntent(SubmitLogoutEvent()),
+      expect: () => [
+        const LogoutState(isLoading: true),
+        const LogoutState(isLoading: false, errorMsg: "Something went wrong"),
+      ],
+      verify: (_) => verify(useCase.invoke()).called(1),
+    );
+  });
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor  
- [x] Feature  
- [ ] Bug Fix  
- [ ] Optimization  
- [ ] Documentation Update  

## ✨ Description  
This PR implements the **logout feature** . 

-Add logout button and it shows an alert dilogue after pressed.
- When pressed logout is call API and logout from account.
- Handled error states with proper error messages.    
- Unit tests added for DataSource, UseCase, Repo, and Cubit.  

## 🎟 Related Ticket  
Closes **ECOM-23** (Logout feature)  


**Screenshots:**  
<img width="259" height="81" alt="image" src="https://github.com/user-attachments/assets/94615f7a-80d7-44ee-b393-ba3a45984681" />

<img width="266" height="193" alt="image" src="https://github.com/user-attachments/assets/a600af2b-fb70-4669-8bc8-6e7c5e9cda73" />

<img width="243" height="96" alt="image" src="https://github.com/user-attachments/assets/b15595f8-5963-4de3-b4aa-3df07a41fc51" />


## ✅ Accessibility Checklist  
- [x] Used semantic widgets (ListTile, Text, OutlinedButton).  
- [x] Added clear error messages on failure.  

## 🧾 Added/updated tests?  
- [x] Yes (Unit + Cubit + UseCase tests+ Repo)  
- [ ] No  

## 🎉 How this PR makes me feel  
![Product Details](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3ajE3ZGl0ejd6NzhmN3J4YmR1b2NzcWFsYzhsZmNmMmIzdG1oZGZsZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/IPWXYMP4t2ODvzwOYk/giphy.gif)
